### PR TITLE
Implement About Us Page UI and contents

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+import React from "react";
+
+export default function AboutPage() {
+  return (
+    <div className="max-w-3xl mx-auto px-6 py-12">
+      <h1 className="text-4xl font-bold mb-6 text-center text-gray-800">About Us</h1>
+      <div className="text-lg text-gray-700 leading-relaxed space-y-4">
+        <p>
+          Welcome to UniQ – a student-driven initiative designed to make campus life easier.
+        </p>
+        <p>
+          When UBIQ, the University of Auckland’s central hub for coursebooks and stationery, announced its closure, students faced the challenge of losing quick access to essential academic supplies. Our team saw this as an opportunity to step in and build a solution tailored for students, by students.
+        </p>
+        <p>
+          At UniQ, our mission is simple: to bring back the convenience of having all your university essentials in one place – now made even easier through a modern, user-friendly website. From textbooks and refill pads to pens, binders, and graph paper, we provide everything you need, delivered right to your door.
+        </p>
+
+        <h2 className="text-2xl font-semibold mt-8 mb-2 text-gray-800">Our Vision</h2>
+        <p>
+          We believe students deserve more time to focus on their studies, not running errands. UniQ combines the practicality of a central campus store with the flexibility of e-commerce – searchable by course, product category, or keyword – ensuring you can always find what you need, quickly and reliably.
+        </p>
+
+        <h2 className="text-2xl font-semibold mt-8 mb-2 text-gray-800">Our Team</h2>
+        <p>
+          We are LuQy No.8, a group of Software Engineering students passionate about technology, collaboration, and solving real-world problems. Together, we aim to create not just a replacement for UBIQ, but an improved digital experience that prioritises:
+        </p>
+        <ul className="list-disc ml-6">
+          <li><strong>Reliability</strong> – Always accessible and dependable</li>
+          <li><strong>Usability</strong> – Simple, intuitive design for students</li>
+          <li><strong>Convenience</strong> – Save time, order online, and focus on what matters most</li>
+        </ul>
+        <p>
+          Through UniQ, we hope to support every student’s academic journey with the tools they need to succeed.
+        </p>
+        <hr className="my-8" />
+        <p>
+          <strong>Contact:</strong> softeng310project@gmail.com
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -10,7 +10,7 @@ export default function Footer() {
           <div className="flex-1 text-center md:text-left">
             <div className="font-bold text-lg text-[#333] mb-2">About us</div>
             <ul className="space-y-1">
-              <li><a href="#" className="text-[#385684] hover:text-[#27406a] transition-colors">About us</a></li>
+              <li><a href="/about" className="text-[#385684] hover:text-[#27406a] transition-colors">About us</a></li>
               <li><a href="#" className="text-[#385684] hover:text-[#27406a] transition-colors">Legal</a></li>
             </ul>
           </div>


### PR DESCRIPTION
Made some description of out web page based on our A1 Project Proposal. Then linked the "About Us Page" to the footer bar to navigate easily.  This completes the ticket of #28 
<img width="1440" height="672" alt="스크린샷 2025-08-18 오후 1 33 05" src="https://github.com/user-attachments/assets/0c780d94-13ac-45ee-bdca-14b0a6dcbccb" />
<img width="513" height="665" alt="스크린샷 2025-08-18 오후 1 33 22" src="https://github.com/user-attachments/assets/03ff8fdd-1f9d-4f97-9f53-a0358750116c" />
