### PR TITLE
Made header sticky and fixed layout and page.tsx

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,6 @@ import './globals.css'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import Navbar from '@/components/common/Navbar'
-import PopCollections from '@/components/home/PopCollections'
 import Footer from '@/components/common/Footer'
 import CourseBooks from './course-books/page'
 
@@ -21,7 +20,13 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <main>{children}</main>
+        <div className="min-h-screen bg-gray-50">
+          <header className="sticky top-0 z-50">
+            <Navbar />
+          </header>
+          {children}
+          <Footer />
+        </div>
       </body>
     </html>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,12 +5,10 @@ import Footer from '@/components/common/Footer'
 export default function Home() {
   return (
     <div className="home">
-      <Navbar />
       <div className="mt-64">
         <h1>New Arrivals</h1>
       </div>
       <PopCollections />
-      <Footer />
     </div>
   )
 }

--- a/components/common/Navbar.tsx
+++ b/components/common/Navbar.tsx
@@ -1,8 +1,7 @@
 "use client"
 import Image from "next/image";
 import Link from "next/link";
-import { MdAccountCircle, MdOutlineShoppingCart , MdClose } from "react-icons/md";
-import { MdOutlineSearch } from "react-icons/md";
+import { MdAccountCircle, MdOutlineShoppingCart , MdClose, MdOutlineSearch } from "react-icons/md";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
 


### PR DESCRIPTION
# Description
- Header bar now sticks to top of page while scrolling
<img width="2251" height="854" alt="image" src="https://github.com/user-attachments/assets/3e15d36f-e8aa-47f4-b811-9254063e497f" />
- Fixed issue where header and footer weren't on every page

This completes issue #49.