### PR TITLE
Added not found and not implemented pages.

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,16 @@
+export default function NotFound() {
+  return (
+    <div className="flex flex-col min-h-screen bg-gray-50 relative overflow-hidden">
+      {/* Faint background text */}
+      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+        <h1 className="text-[25rem] font-bold text-gray-100 select-none">UniQ</h1>
+      </div>
+      {/* Main 404 Content */}
+      <main className="flex-grow flex flex-col items-center justify-center text-center px-4 relative z-10">
+        <h1 className="text-8xl font-extrabold text-[#385684]">404</h1>
+        <p className="mt-6 text-3xl text-[#385684]">Page Not Found</p>
+        <div className="mt-8 text-7xl text-[#385684]">˙◠˙</div>
+      </main>
+    </div>
+  );
+}

--- a/app/not-implemented/page.tsx
+++ b/app/not-implemented/page.tsx
@@ -1,0 +1,9 @@
+import NotImplementedPage from '@/components/not-implemented/notImplementedPage';
+
+export default function NotImplemented() {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <NotImplementedPage />
+    </div>
+  )
+}

--- a/components/not-implemented/notImplementedPage.tsx
+++ b/components/not-implemented/notImplementedPage.tsx
@@ -1,0 +1,16 @@
+export default function NotImplemented() {
+  return (
+    <div className="flex flex-col min-h-screen bg-gray-50 relative overflow-hidden">
+      {/* Faint background text */}
+      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+        <h1 className="text-[25rem] font-bold text-gray-100 select-none">UniQ</h1>
+      </div>
+      {/* Main Not Implemented Content */}
+      <main className="flex-grow flex flex-col items-center justify-center text-center px-4 relative z-10">
+        <h1 className="text-8xl font-extrabold text-[#385684]">Error</h1>
+        <p className="mt-6 text-3xl text-[#385684]">Not Implemented Yet</p>
+        <div className="mt-8 text-7xl text-[#385684]">˙◠˙</div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
Added a not implemented page, which the team can use when there is a page that is not implemented yet. Also made a 404 not found page that works with the functionality of any other 404 page. Resolves issue #27 

This is the image of 404 Not Found page, the not implemented is the same although says Error Not Implemented Yet.
<img width="3000" height="1736" alt="image" src="https://github.com/user-attachments/assets/b572d9c3-3f63-464e-97e0-b0d6125c05c3" />
