### PR TITLE
fixed NoteBooks image calling in New Arrivals

### DIFF
--- a/components/home/NewArrivals.tsx
+++ b/components/home/NewArrivals.tsx
@@ -3,7 +3,7 @@ import React, { useState, useRef } from "react";
 import Image from "next/image";
 
 // Default image for all items
-const defaultImage = "/assets/NoteBooks.png";
+const defaultImage = "/assets/NoteBooks.webp";
 
 // Hardcoded list of 8 items
 const items = [


### PR DESCRIPTION
Calling NoteBooks was kept as a .png within the NewArrivals component and this PR changes it correctly to a webp. Before this change this error would occur even though the website loaded correctly:
<img width="1461" height="216" alt="image" src="https://github.com/user-attachments/assets/64b5622e-cbf6-4617-a0a2-7a0d45242a73" />
After the changes, this is what is shown:
<img width="600" height="284" alt="image" src="https://github.com/user-attachments/assets/339ee169-58d7-48be-b5bf-a4656766f3c4" />
This completes #21 fully and the issue can be closed.